### PR TITLE
generate.py: Separate validate and build stages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 out
+cache

--- a/generate.py
+++ b/generate.py
@@ -9,8 +9,14 @@ import io
 import time
 import requests
 import jsonschema
+import hashlib
 from PIL import Image
 
+
+BOARDS_DIR = 'boards'
+TEMPLATE_DIR = 'page_template'
+OUTPUT_DIR = 'out'
+CACHE_DIR = 'cache'
 
 BOARD_SCHEMA = {
     'type': 'object',
@@ -67,24 +73,32 @@ def generate_thumbnail(image_url, max_size=(64, 64), quality=85):
     if not image_url:
         return None
 
+    cache_file = os.path.join(CACHE_DIR, hashlib.sha256(image_url.encode('utf-8')).hexdigest())
+
     try:
-        print('\tFetching image... ', end='\r')
+        if not os.path.exists(cache_file):
+            print('\tFetching image... ', end='\r')
 
-        req = requests.get(image_url, stream=True, timeout=10)
+            req = requests.get(image_url, stream=True, timeout=10)
 
-        total_size = int(req.headers.get('content-length', 0))
-        downloaded = 0
-        image_data = bytearray()
+            total_size = int(req.headers.get('content-length', 0))
+            downloaded = 0
+            image_data = bytearray()
 
-        with req as r:
-            r.raise_for_status()
-            for chunk in r.iter_content(1024):
-                downloaded += len(chunk)
-                image_data.extend(chunk)
-                print(f'\tFetching image... {downloaded / total_size:.0%}', end='\r')
-        print('', end='\r')
+            with req as r:
+                r.raise_for_status()
+                for chunk in r.iter_content(1024):
+                    downloaded += len(chunk)
+                    image_data.extend(chunk)
+                    print(f'\tFetching image... {downloaded / total_size:.0%}', end='\r')
+            print('', end='\r')
 
-        with Image.open(io.BytesIO(image_data)) as img:
+            open(cache_file, 'wb').write(image_data)
+        
+        else:
+            print(f'\tUsing cached image: {cache_file}')
+
+        with Image.open(cache_file) as img:
             if img.mode in ('RGBA', 'LA', 'P'):
                 background = Image.new('RGB', img.size, (255, 255, 255))
 
@@ -109,10 +123,10 @@ def generate_thumbnail(image_url, max_size=(64, 64), quality=85):
         return None
 
 
-def validate(filename, boards_dir):
+def validate(filename, BOARDS_DIR):
     print(f'Validating "{filename}"...')
 
-    filepath = os.path.join(boards_dir, filename)
+    filepath = os.path.join(BOARDS_DIR, filename)
 
     try:
         with open(filepath, 'r', encoding='utf-8') as f:
@@ -133,10 +147,10 @@ def validate(filename, boards_dir):
         return False
 
 
-def parse(filename, boards_dir):
+def parse(filename, BOARDS_DIR):
     print(f'Processing "{filename}"...')
 
-    filepath = os.path.join(boards_dir, filename)
+    filepath = os.path.join(BOARDS_DIR, filename)
 
     try:
         with open(filepath, 'r', encoding='utf-8') as f:
@@ -176,46 +190,42 @@ def parse(filename, boards_dir):
 
 
 def main():
-    boards_dir = 'boards'
-    template_dir = 'page_template'
-    output_dir = 'out'
+    if not os.path.exists(BOARDS_DIR):
+        sys.exit(f'Error: Directory "{BOARDS_DIR}" not found!')
 
-    if not os.path.exists(boards_dir):
-        sys.exit(f'Error: Directory "{boards_dir}" not found!')
+    if not os.path.exists(TEMPLATE_DIR):
+        sys.exit(f'Error: Directory "{TEMPLATE_DIR}" not found!')
 
-    if not os.path.exists(template_dir):
-        sys.exit(f'Error: Directory "{template_dir}" not found!')
+    if os.path.exists(OUTPUT_DIR):
+        shutil.rmtree(OUTPUT_DIR)
 
-    if os.path.exists(output_dir):
-        shutil.rmtree(output_dir)
+    if not os.path.exists(CACHE_DIR):
+        os.makedirs(CACHE_DIR, exist_ok=True)
 
-    os.makedirs(output_dir, exist_ok=True)
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
 
-    files = [filename for filename in os.listdir(boards_dir) if filename.endswith('.yaml') and not filename == '_template.yaml']
+    files = [filename for filename in os.listdir(BOARDS_DIR) if filename.endswith('.yaml') and not filename == '_template.yaml']
     files.sort()
 
-    valid = [validate(filename, boards_dir) for filename in files]
+    valid = [validate(filename, BOARDS_DIR) for filename in files]
 
     if False in valid:
         sys.exit('\nErrors found during validation. Aborting!')
 
-    if len(sys.argv) >= 2 and sys.argv[1] == "--validate-only":
-        print('\nValidation OK!')
-        sys.exit(0)
-
-    all_data = [parse(filename, boards_dir) for filename in files]
+    all_data = [parse(filename, BOARDS_DIR) for filename in files]
 
     if False in all_data:
         sys.exit('\nErrors found during processing. Aborting!')
 
-    json_path = os.path.join(output_dir, 'board_data.json')
+    json_path = os.path.join(OUTPUT_DIR, 'board_data.json')
     with open(json_path, 'w', encoding='utf-8') as f:
         json.dump({'data': all_data}, f, indent=2)
+
     print(f'Successfully wrote {len(all_data)} boards to "{json_path}"!')
 
-    for item in os.listdir(template_dir):
-        src = os.path.join(template_dir, item)
-        dest = os.path.join(output_dir, item)
+    for item in os.listdir(TEMPLATE_DIR):
+        src = os.path.join(TEMPLATE_DIR, item)
+        dest = os.path.join(OUTPUT_DIR, item)
 
         if os.path.isdir(src):
             shutil.copytree(src, dest, dirs_exist_ok=True)


### PR DESCRIPTION
Add a crude `--validate-only` flag (should probably use argparse 😭) so boards can be validated against the schema without building them all. Saves the wait - and all the fetched images - to check if a new addition 👀 has been validated.

Also sneaks in `sys.exit()` since `exit()` is weird and contentious for reasons I can't even remember.

If I'm being pedantic it might be nice to have the schema in a standalone .json file too.